### PR TITLE
Add babel to support ES2015 (ES6)

### DIFF
--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -9,6 +9,6 @@ require('./example');
 // load sass manifest
 require('../styles/index.scss');
 
-$(document).ready(function() {
+$(document).ready(() => {
   console.log('It works.');
 });

--- a/grunt/webpack.js
+++ b/grunt/webpack.js
@@ -25,6 +25,14 @@ module.exports = {
     ],
     module: {
       loaders: [
+        {
+          test: /\.js$/,
+          exclude: /(node_modules|bower_components)/,
+          loader: 'babel',
+          query: {
+            presets: ['es2015']
+          }
+        },
         { test: /\.scss$/, loader: 'style!css!sass' }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "jquery": "^2.1.4"
   },
   "devDependencies": {
+    "babel-core": "^6.4.5",
+    "babel-loader": "^6.2.1",
+    "babel-preset-es2015": "^6.3.13",
     "css-loader": "^0.23.1",
     "expose-loader": "^0.7.1",
     "grunt": "^0.4.5",


### PR DESCRIPTION
Use an arrow function to test functionality in Safari