### PR TITLE
Get form data

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,4 +16,4 @@ require('expose?jQuery!jquery');
 
 // attach urlFormData globally
 
-require('expose?formUrlencoded!./lib/wiring/x-www-form-urlencoded.js');
+require('expose?getFormData!./lib/wiring/x-www-form-urlencoded.js');

--- a/index.js
+++ b/index.js
@@ -13,3 +13,7 @@ require('./assets/styles/index.scss');
 // attach jQuery globally
 require('expose?$!jquery');
 require('expose?jQuery!jquery');
+
+// attach urlFormData globally
+
+require('expose?formUrlencoded!./lib/wiring/x-www-form-urlencoded.js');

--- a/lib/wiring/get-form-data.js
+++ b/lib/wiring/get-form-data.js
@@ -1,7 +1,12 @@
 'use strict';
 
-const formUrlencoded = (form) => {
+const getFormData = (form) => {
   const enc = encodeURIComponent;
+
+  if (form.enctype === 'multipart/form-data') {
+    return new FormData(form);
+  }
+
   let elements = form.elements || [];
   let result = [];
   for (let i = 0; i < elements.length; i++) {
@@ -21,4 +26,4 @@ const formUrlencoded = (form) => {
   return result.join('&');
 };
 
-module.exports = formUrlencoded;
+module.exports = getFormData;

--- a/lib/wiring/x-www-form-urlencoded.js
+++ b/lib/wiring/x-www-form-urlencoded.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const formUrlencoded = (form) => {
+  const enc = encodeURIComponent;
+  let elements = form.elements || [];
+  let result = [];
+  for (let i = 0; i < elements.length; i++) {
+    let e = elements[i];
+    if (!e.hasAttribute('name')) {
+      continue;
+    }
+
+    let type = e.nodeName.toUpperCase() === 'INPUT' ?
+      e.getAttribute('type').toUpperCase() : 'TEXT';
+    if ((type !== 'RADIO' && type !== 'CHECKBOX') ||
+        e.checked) {
+      result.push(`${enc(e.name)}=${enc(e.value)}`);
+    }
+  }
+
+  return result.join('&');
+};
+
+module.exports = formUrlencoded;


### PR DESCRIPTION
This allows consistency between `multipart/form-data` and `application/x-www-form-urlencoded` form submissions, e.g.

```js
const myFormApiCreate = (data, success, fail) => {
  $.ajax({
    method: 'POST',
    url: 'http://localhost:3000/forms',
    processData: false,
    data: data,
  }).done(success)
  .fail(fail);
};

$('#my-form').on('submit', function (e) {
  let formData = getFormData(this);
  myFormApiCreate(formData, (success) => console.log(success), (fail) => console.error(fail));
});
```